### PR TITLE
Suggestion: improve email readability

### DIFF
--- a/docs/_layouts/email.html
+++ b/docs/_layouts/email.html
@@ -18,6 +18,32 @@
         }
         
         {{ site.data.styles }}
+
+        /* Email-only readability overrides.
+           Web styles above stay untouched; these apply solely to the email layout.
+           Font sizes are relative (em) so they scale with the reader's default
+           text size and never render below it. */
+        body {
+            font-size: 1.25em;
+            line-height: 1.6;
+        }
+
+        p {
+            font-size: 1.1em;
+            margin: 14px 0;
+        }
+
+        h3 {
+            margin-top: 48px;
+        }
+
+        a.author {
+            font-size: 0.9em;
+        }
+
+        .footer ul li {
+            font-size: 0.9em;
+        }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Email-only font-size and spacing tweaks — body text scales up relative to the reader's default (1.25em ≈ 20px, paragraphs 1.1em ≈ 22px), plus breathing room around paragraphs and titles; width, colors and structure untouched.

## Before
![Before](https://raw.githubusercontent.com/Snapp-Mobile/ios-newsletter/assets/email-readability/before-2x.png)

## After
![After](https://raw.githubusercontent.com/Snapp-Mobile/ios-newsletter/assets/email-readability/after-22-2x.png)